### PR TITLE
Fix the fontawesome icons

### DIFF
--- a/docs/advanced/images.md
+++ b/docs/advanced/images.md
@@ -18,12 +18,12 @@ Windows KVM 仅为有需要的用户提供，由于 Windows 的系统设计与 L
 
     | 功能特性 | Linux LXC | Linux KVM | Windows KVM |
     | :------: | :------: | :------: | :------: |
-    | [使用 VNC 登录](../login/vnc.md) | :fontawesome-solid-check-circle:{: .limegreen } | :fontawesome-solid-times-circle:{: .orangered } | :fontawesome-solid-times-circle:{: .orangered } |
-    | [使用 SSH 登录](../login/ssh.md) | :fontawesome-solid-check-circle:{: .limegreen } | :fontawesome-solid-check-circle:{: .limegreen } | :fontawesome-solid-times-circle:{: .orangered } |
-    | [使用 RDP 登录](../login/rdp.md) | :fontawesome-solid-times-circle:{: .orangered } | :fontawesome-solid-times-circle:{: .orangered } | :fontawesome-solid-check-circle:{: .limegreen } |
-    | Vlab 实验软件套装 | :fontawesome-solid-check-circle:{: .limegreen } | :fontawesome-solid-times-circle:{: .orangered } | :fontawesome-solid-times-circle:{: .orangered } |
-    | Linux 高级特性 | :fontawesome-solid-times-circle:{: .orangered } | :fontawesome-solid-check-circle:{: .limegreen } | :fontawesome-solid-times-circle:{: .orangered } |
-    | 技术支持 | :fontawesome-solid-question-circle:{: .darkcyan } | :fontawesome-solid-question-circle:{: .darkcyan } | :fontawesome-solid-times-circle:{: .orangered } |
+    | [使用 VNC 登录](../login/vnc.md) | :fontawesome-solid-circle-check:{: .limegreen } | :fontawesome-solid-circle-xmark:{: .orangered } | :fontawesome-solid-circle-xmark:{: .orangered } |
+    | [使用 SSH 登录](../login/ssh.md) | :fontawesome-solid-circle-check:{: .limegreen } | :fontawesome-solid-circle-check:{: .limegreen } | :fontawesome-solid-circle-xmark:{: .orangered } |
+    | [使用 RDP 登录](../login/rdp.md) | :fontawesome-solid-circle-xmark:{: .orangered } | :fontawesome-solid-circle-xmark:{: .orangered } | :fontawesome-solid-circle-check:{: .limegreen } |
+    | Vlab 实验软件套装 | :fontawesome-solid-circle-check:{: .limegreen } | :fontawesome-solid-circle-xmark:{: .orangered } | :fontawesome-solid-circle-xmark:{: .orangered } |
+    | Linux 高级特性 | :fontawesome-solid-circle-xmark:{: .orangered } | :fontawesome-solid-circle-check:{: .limegreen } | :fontawesome-solid-circle-xmark:{: .orangered } |
+    | 技术支持 | :fontawesome-solid-circle-question:{: .darkcyan } | :fontawesome-solid-circle-question:{: .darkcyan } | :fontawesome-solid-circle-xmark:{: .orangered } |
 
 ## 镜像选择 {#image-selection}
 


### PR DESCRIPTION
之前引用的 fontawesome 的 icon 都失效了，现在修复一下。

修复前

<img width="711" alt="截屏2022-05-30 11 05 37" src="https://user-images.githubusercontent.com/61791143/170910717-218694c7-6b22-4883-8787-7a4e588e137c.png">

修复后

<img width="700" alt="截屏2022-05-30 11 05 54" src="https://user-images.githubusercontent.com/61791143/170910741-9570508c-3bce-476b-b859-69f7b2d8240c.png">

